### PR TITLE
Make one release publishing

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -9,7 +9,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        python-version: [ '3.8', '3.9', '3.10', '3.11', '3.12' ]
+        python-version: [ '3.11' ]
         os: [ ubuntu-latest ]
     runs-on: ${{ matrix.os }}
     steps:


### PR DESCRIPTION
Поправлен workflow публикации.

Для публикации проекта в PyPI используется только одна версия python3.11